### PR TITLE
Add a missing entry point option to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -84,3 +84,7 @@ where = .
 
 [flake8]
 max-line-length = 88
+
+[options.entry_points]
+molecule.driver =
+    hetznercloud = molecule_hetznercloud.hetznercloud:HetznerCloud


### PR DESCRIPTION
This package did not specify its entry point for molecule driver. And because of that, molecule failed to pick it up while running.

This commit is a minimal fix to get the driver to talk with molecule.